### PR TITLE
add ID for resourcegroup to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Description: The ID of the generated proximity placement group
 ### resource\_group
 
 Description: The name of the generated resource group
+
+### resource\_group\_id
+
+Description: The ID of the generated resource group
 <!-- END_TF_DOCS -->
 
 ## Development

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "resource_group" {
   value       = azurerm_resource_group.azure-resource-group.name
 }
 
+output "resource_group_id" {
+  description = "The ID of the generated resource group"
+  value       = azurerm_resource_group.azure-resource-group.id
+}
+
 output "location" {
   description = "The location input variable (can be used for dependency resolution)"
   value       = var.location


### PR DESCRIPTION
The generated resource group ID was missing. We need that for creating resource locks per resource group.